### PR TITLE
Update ingestion pipeline.yml for tutorials

### DIFF
--- a/docs/ingesting_data/pipeline.yml
+++ b/docs/ingesting_data/pipeline.yml
@@ -1,71 +1,35 @@
-# ----------------------- #
-# QC pipeline DendrouLab
-# ----------------------- #
-# written by Charlotte Rich-Griffin, Thom Tomas, Fabiola Curion
+# ============================================================
+# Ingest workflow Panpipes (pipeline_ingest.py)
+# ============================================================
+# This file contains the parameters for the ingest workflow.
+# For full descriptions of the parameters, see the documentation at https://panpipes-pipelines.readthedocs.io/en/latest/yaml_docs/pipeline_ingestion_yml.html
 
-# needs a sample metadata file (see resources for an example)
-# will run :
-#   summary plots of 10x metrics
-#   scrublet scores
-#   scanpy QC
-#   summary QC plots
 
-# Followed by preprocess pipeline. 
-# The ingest pipeline does not perform any filtering of cells or genes.
-# Filtering happens as the first step in the preprocess pipeline. See pipeline_preprocess for details
-
-# Note that if you are combining multiple datasets from different source the final anndata object will only contain the intersect of the genes
-# from all the data sets. For example if the mitochondrial genes have been excluded from one of the inputs, they will be excluded from the final data set.
-# In this case it might be wise to run qc separately on each dataset, and them merge them together to create on h5ad file to use as input for
-# integration pipeline.
-# ------------------------
-# compute resource options
-# ------------------------
+#--------------------------
+# Compute resources options
+#--------------------------
 resources:
-  # Number of threads used for parallel jobs
-  # this must be enough memory to create to load all you input files and once and create the mudatafile
   threads_high: 1
-  # this must be enough memory to load your mudata and do computationally light tasks
   threads_medium: 1
-  # this must be enough memory to load text files and do plotting, requires much less memory than the other two
   threads_low: 1
-#Change path to conda env, leave blank if running native or your cluster automatically inherits the login node environment
+
 condaenv: pipeline_env
 
-# ------------------------------------------------------------------------------------------------
-# Loading and concatenating data options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
+# --------------------------------
+# Loading and merging data options
+# --------------------------------
+
+# ----------------------------
 # Project name and data format
-# ------------------------
 project: Teaseq
 sample_prefix: teaseq
-# if you have an existing h5mu object that you want to run through the pipeline then
-# store it in the folder where you intend to run the workflow, and call it
-# ${sample_prefix}_unfilt.h5mu where ${sample_prefix} = sample_prefix argument above
 use_existing_h5mu: False
-
-# submission_file format:
-# For qc_mm the required columns are
-# sample_id  rna_path  rna_filetype  (prot_path  prot_filetype tcr_path  tcr_filetype etc.)
-# Example at resources/sample_file_mm.txt
 submission_file: sample_file_qc.txt
-
-# which metadata cols from the submission file do you want to include in the anndata object
-# as a comma-separated string e.g. batch,disease,sex
-metadatacols: 
-
-# which concat join do you want to perform on your mudata objects, recommended is inner
-# see https://anndata.readthedocs.io/en/latest/concatenation.html#inner-and-outer-joins for details
+metadatacols:
 concat_join_type: inner
 
-
-#---------------------------------------
+#--------------------------
 # Modalities in the project
-#---------------------------------------
-# the qc scripts are independent and modalities are processed following this order. Set to True to abilitate modality(ies). 
-# Leave empty (None) or False to signal this modality is not in the experiment.
-
 modalities:
   rna: True
   prot: True
@@ -73,285 +37,103 @@ modalities:
   tcr: False
   atac: True
 
-#---------------------------------------
-# Integrating barcode level data e.g. 
-# demultiplexing with hashtags, chemical tags or lipid tagging
-#---------------------------------------
-# if you have cell level metadata such as results from a demultiplexing algorithm, 
-# you can incorporate it into the mudata object, 
-# this should be stored in one csv containing 2 columns, barcode_id, and sample_id,
-# which should match the sample_id column in the submission file.
+#--------------------------------
+# Integrating barcode level data
+# e.g. demultiplexing with hashtags, chemical tags or lipid tagging
 barcode_mtd:
   include: False
   path:
   metadatacols:  
 
-#---------------------------------------
-# Loading PROT data - additional options
-#---------------------------------------
-# As default the ingest will choose the first column of the cellranger features.tsv.gz
-# To merge extra information about the antibodies e.g. whether they are hashing antibodies or isotypes,
-# Create a table with the first column equivalent to the first column of cellrangers features.tsv.gz
-# and specify it below (save as txt file)
-protein_metadata_table: 
-# Make sure there are unique entries in this column for each adt.
-# include a column called isotype (containing True or False) if you want to qc isotypes
-# include a column called hashing_ab (containing True or False) if your dataset contains hashing antibodies which you wish to split into a separate modality
-
-# If you want to update the mudata index with a column from protein_metadata_table, specify here
-# If there are overlaps with the rna gene symbols, then you might have trouble down the line
-# It is recommended to add something to make the labels unique e.g. "adt_CD4"
-index_col_choice: 
-
-# If providing separate prot and rna 10X outputs, then the pipeline will load the filtered rna 10X outputs and the raw prot 10X counts
-# we assume in most cases that we want to treat filtered rna barcodes as the "real" cells
-# and we want out prot assays barcodes to match rna. In which case set subset_prot_barcodes_to_rna: True (which is also the default setting)
-# if explicitly set to False, the full prot matrix will be loaded into the mudata object
+#------------------------------------------
+# Loading Protein data - additional options
+protein_metadata_table:
+index_col_choice:
 load_prot_from_raw: False
 subset_prot_barcodes_to_rna: False
 
 
-# ------------------------------------------------------------------------------------------------
-# QC options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
-# 10X cellranger files processing
-# ------------------------
-# if starting from cellranger outputs, you can parse multiple metrics_summary.csv files and plot them together
-# the workflow looks for the metrics_summary file in the "outs" folder and will stop if it doesn't find it.
-plot_10X_metrics: False #Set to False if not using cellranger folders as input
+# -----------------------------
+# Quality Control (QC) options
+# -----------------------------
 
-# ------------------------
-# Doublets on RNA - Scrublet
-# ------------------------
+# -----------------------------------
+# Processing of 10X cellranger metrics files
+plot_10X_metrics: False
+
+# ----------------------------------
+# Doublet detection on RNA modality
 scr:
   run: True
-  # The values here are the default values, if you were to leave a paramter pblank, it would default to these value,
   expected_doublet_rate: 0.06
-  #the expected fraction of transcriptomes that are doublets, typically 0.05-0.1.
-  # Results are not particularly sensitive to this parameter")
   sim_doublet_ratio: 2
-  # the number of doublets to simulate, relative to the number of observed transcriptomes.
-  # Setting too high is computationally expensive. Min tested 0.5
   n_neighbours: 20
-  # Number of neighbors used to construct the KNN classifier of observed transcriptomes
-  # and simulated doublets.
-  # The default value of round(0.5*sqrt(n_cells)) generally works well.
   min_counts: 2
-  # Used for gene filtering prior to PCA. Genes expressed at fewer than `min_counts` in fewer than `min_cells` (see below) are excluded"
   min_cells: 3
-  # Used for gene filtering prior to PCA.
-  # Genes expressed at fewer than `min_counts` (see above) in fewer than `min_cells` are excluded.")
   min_gene_variability_pctl: 85
-  # Used for gene filtering prior to PCA. Keep the most highly variable genes
-    # (in the top min_gene_variability_pctl percentile),
-    #as measured by the v-statistic [Klein et al., Cell 2015]")
   n_prin_comps: 30
-  # Number of principal components used to embed the transcriptomes
-  # prior to k-nearest-neighbor graph construction
   use_thr: True
-  # use a user defined thr to define min doublet score to split true from false doublets?
-  # if false just use what the software produces
-  # this threshold applies to plots, a=no actual fitlering takes place.
   call_doublets_thr: 0.25
-  #if use_thr is True, this thr will be used to define doublets
 
-# ------------
-# RNA QC
-# ------------
-# this part of the pipeline allows to generate the QC parameters that will be used to 
-# evaluate inclusion/ exclusion criteria. Filtering of cells/genes happens in the next workflow (preprocess)
-# leave options blank to avoid running, "default" (to use the data stored within the package) 
+# ----------------------------
+# RNA modality Quality Control
 
-# It's often practical to rely on known gene lists, for a series of tasks, like evaluating % of mitochondrial genes or
-# ribosomal genes, or excluding IGG genes from HVG selection. For the ingest workflow, 
-# We collect the cellcycle genes used in scanpy.score_genes_cell_cycle [Satija et al. (2015), Nature Biotechnology.] 
-# in in a file, panpipes/resources/cell_cicle_genes.tsv
-# and an example gene list in panpipes/resources/qc_genelist_1.0.csv 
+# Providing a gene list
+# see documentation at https://panpipes-pipelines.readthedocs.io/en/latest/usage/gene_list_format.html
+custom_genes_file: qc_genelist_1.0.csv
 
-# | mod | feature| group  |
-# |-----| -------|--------|
-# | RNA | gene_1 | mt     |
-# | RNA | gene_2 | rp     |
-# | RNA | gene_1 | exclude|
-# | RNA | gene_1 | markerX|  
-
-
-# We define "actions" on them as follows:
-
-# specify the "group" name of the genes you want to use to apply the action i.e. calc_proportion: mt will calculate
-# proportion of reads mapping to the genes whose group is "mt"
+# Defining actions on the genes
 
 # (for pipeline_ingest.py)
-# calc_proportions: calculate proportion of reads mapping to X genes over total number of reads, per cell
-# score_genes: using scanpy.score_genes function, 
-
-# (for pipeline_integration.py)
-# exclude: exclude these genes from the HVG selection, if they are deemed HV.
-
-
-#-------------------------
-# cell cycle action
-#-------------------------
-# ccgenes will plot the proportions of cell cycle genes (recommended to leave as default)
-ccgenes: default
-# Setting the `ccgenes` to `default` will calculate the phase of the cell cycle in which the cell is by using 
-# `scanpy.tl.score_genes_cell_cycle` using the file provided in panpipes/resources/cell_cicle_genes.tsv
-# Users can create their own list and specify the path in the `ccgenes` param to score the cells with a custom list.
-# If left blank, the cellcycle score will not be calculated.
-
-#-------------------------
-# custom genes actions#-------------------------
-# Make sure that the qc_genelist_1.0.cs file is in the current directory (data.dir) 
-custom_genes_file: qc_genelist_1.0.csv
 calc_proportions: hb,mt,rp,ig
 score_genes: MarkersNeutro
 
-# -------------------
-# Plot QC
-# -------------------
-# all metrics should be inputted as a comma separated string e.g. a,b,c
+# cell cycle action
+ccgenes: default
 
-# base of the plots, it is a column in the obs, can be a comma separated string of multiple categorical 
-# plotqc_grouping_var: sample_id,rna:channel,prot:sample
-# normally is the channel also referred to "sample_id"
-# if left blank, the base of the plot will be the `sample_id` of your submission file
+# ------------------------
+# Plotting RNA QC metrics
+# all metrics should be provided as a comma separated string e.g. a,b,c
 plotqc_grouping_var: orig.ident
-
-
-# ------------
-# Plot RNA QC metrics
-# ------------
-# other cell covariates in rna .obs
 plotqc_rna_metrics: doublet_scores,pct_counts_mt,pct_counts_rp,pct_counts_hb,pct_counts_ig
 
-# ------------
-# Plot PROT QC metrics
-# ------------
-# requires prot_path to be included in the submission file
-# all metrics should be inputted as a comma separated string e.g. a,b,c
+# ----------------------------
+# Plotting Protein QC metrics
 
-# as standard the following metrics are calculated for prot data
-# per cell metrics:
-# total_counts,log1p_total_counts,n_adt_by_counts,log1p_n_adt_by_counts
-# if isotypes can be detected then the following are calculated also:
-# total_counts_isotype,pct_counts_isotype
-# choose which ones you want to plot here
+# requires prot_path to be included in the submission file
+# all metrics should be provided as a comma separated string e.g. a,b,c
 plotqc_prot_metrics: total_counts,log1p_total_counts,n_adt_by_counts,pct_counts_isotype
-# Since the protein antibody panels usually count fewer features than the RNA, it may be interesting to
-# visualize breakdowns of single proteins plots describing their count distribution and other qc options.
-# choose which ones you want to plot here, for example
-# n_cells_by_counts,mean_counts,log1p_mean_counts,pct_dropout_by_counts,total_counts,log1p_total_counts
 prot_metrics_per_prot: total_counts,log1p_total_counts,n_cells_by_counts,mean_counts
 
-# isotype outliers: one way to determine which cells are very sticky is to work out which cells have the most isotype UMIs
-# associated to them, to label a cell as an isotype outlier, it must meet or exceed the following crietria:
-# be in the above x% quantile by UMI counts, for at least n isotypes 
-# (e.g. above 90% quantile UMIs in at least 2 isotypes)
 identify_isotype_outliers: True
 isotype_upper_quantile: 90
 isotype_n_pass: 2
 
-### Investigate per channel antibody staining:
-# This can help determine any inconsistencies in staining per channel and other QC concerns.
-# If you want to run clr normalsiation on a per channel basis, then you need to 
-# specify which column in your submission file corresponds to the channel
-# at the QC stage it can be useful to look at the normalised data on a per channel basis 
-# i.e. the 10X channel. 
-# this is usually the sample_id column (otherwise leave the next parameter blank)
-channel_col: sample_id
-# It is important to note that in qc_mm the per channel normalised adt scores are not saved in the mudata object
-#  this is because if you perform feature normalisation (clr normalisation margin 0 or dsb normalisation), 
-#  on subsets of cells then the normalised values cannot be simply concatenated. 
-# The ADT normalisation is rerun pn the complete object in the preprocess pipeline 
-# (or you can run this pipeline with channel_col set as None)
-# it is important to note, if you choose to run the clr on a per channel basis, then it is not stored in the h5mu file.
-# if you want to save the per channel normalised values set the following to True:
-save_norm_prot_mtx: False
+# ---------------------
+# Plot ATAC QC metrics
 
-# comma separated string of normalisation options
-# options: dsb,clr 
-# more details in this vignette https://muon.readthedocs.io/en/latest/omics/citeseq.html
-# dsb https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.dsb.html
-# clr https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.clr.html
-normalisation_methods: clr
-
-# CLR parameters:
-# margin determines whether you normalise per cell (as you would RNA norm), 
-# or by feature (recommended, due to the variable nature of adts). 
-# CLR margin 0 is recommended for informative qc plots in this pipeline
-# 0 = normalise rowwise (per feature)
-# 1 = normalise colwise (per cell)
-clr_margin: 1
-
-
-# DSB parameters:
-# quantile clipping, even with normalisation, 
-# some cells get extreme outliers which can be clipped as discussed https://github.com/niaid/dsb
-# maximum value will be set at the value of the 99.5% quantile, applied per feature
-# note that this feature is in the default muon mu.pp.dsb code, but manually implemented in this code.
-quantile_clipping: True
-# in order to run DSB you must have access to the complete raw counts, including the empty droplets 
-# from both rna and protein assays, 
-# see details for how to make sure your files are compatible in the assess background section below
-
-
-# ------------
-# Plot ATAC QC metrics 
-# ------------
-
-# we require initializing one csv file per aggregated ATAC/multiome experiment.
-# if you need to analyse multiple samples in the same project, aggregate them with the cellranger arc pipeline
-# for multiome samples we recommend, specifying the 10X h5 input "10x_h5"
-# per_barcode_metric is only avail on cellranger arc (multiome)
-
-#is this an ATAC alone or a multiome sample?
+# set is_paired to True if a multiome is ingested
 is_paired: True
-#this is NOT a multiome exp, but you have an RNA anndata that you would like to use for TSS enrichment, 
-#leave empty if no rna provided
-partner_rna: 
-#if this is a standalone atac (is_paired: False), please provide a feature file to run TSS enrichment.
-#supported annotations for protein coding genes provided
+# If this is NOT a multiome experiment, but you have an RNA anndata that you would like to use for TSS enrichment
+# use the partner_rna to specify the path to the file and provide a features_tss file with the tss coordinates
+# leave empty if multiome is used
+partner_rna:
 features_tss: #resources/features_tss_hg19.tsv
-#these will be used to plot and saved in the metadata
-# all metrics should be inputted as a comma separated string e.g. a,b,c
 plotqc_atac_metrics: n_genes_by_counts,total_counts,pct_fragments_in_peaks,atac_peak_region_fragments,atac_mitochondrial_reads,atac_TSS_fragments
 
-# ------------
+# ---------------------------
 # Plot Repertoire QC metrics
-# ------------
-# Repertoire data will be stored in one modality called "rep", if you provide both TCR and BCR data then this will be merged, 
-# but various functions will be fun on TCR and BCR separately
-# Review scirpy documentation for specifics of data storage https://scverse.org/scirpy/latest/index.html
-
-# compute sequence distance metric (required for clonotype definition)
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.pp.ir_dist.html#scirpy.pp.ir_dist
-# leave blank for defaults
 ir_dist:
   metric:
   sequence:
 
-# clonotype definition 
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.tl.define_clonotypes.html#scirpy.tl.define_clonotypes
-# leave blank for defaults
 clonotype_definition:
   receptor_arms:
   dual_ir:
   within_group:
 
-# available metrics
-# rep:clone_id_size
-# rep:clonal_expansion
-# rep:receptor_type
-# rep:receptor_subtype
-# rep:chain_pairing
-# rep:multi_chain
-# rep:high_confidence
-# rep:is_cell
-# rep:extra_chains
 plotqc_rep_metrics:
+# provide a item list
  - is_cell
  - extra_chains
  - clonal_expansion
@@ -360,31 +142,44 @@ plotqc_rep_metrics:
  - rep:chain_pairing
  - rep:multi_chain
 
-  
-# ------------
+
+# -------------------------------------
 # Profiling Protein Ambient background
-# ------------
-# It is useful to characterise the background of your gene expression assay and antibody binding assay.
-# Inspect the plots and decide if to apply corrections, for example see Cellbender or SoupX. (currently not included in panpipes)
-# Please note that this analysis can only be performed if you are providing a RAW input starting from cellranger outputs
-# (so the "empty" droplets can be used to  estimate the BG )
-# Setting `assess_background` to True will:
-# 1. create h5mu from raw data inputs (expected as cellranger h5 or mtx folder, if you do not have this then set to False)
-# 2. Plot comparitive QC plots to compare distribution of UMI and feature counts in background and foreground
-# 3. Create heatmaps of the top features in the background, so you can compare the background contamination per channel
+# -------------------------------------
+# PLEASE NOTE that this analysis can only be run if your inputs are from cellranger raw outputs
+
 assess_background: False
-# typically there is a lot of cells in the full raw cellranger outputs, 
-# since we just want to get a picture of the background then we can subsample the data 
-# to a more reasonable ize. If you want to keep all the raw data then set the following to False
 downsample_background: True
 
-# Files required for profiling ambient background or running dsb normalisation:
 # -----------------------------------------------------
-# the raw_feature_bc_matrix folder from cellranger or equivalent.
-# The pipeline will automatically look for this as a .h5 or matrix folder 
-# if the {mod}_filetype is set to "cellranger" or "cellranger_multi" or 10X_h5 
-# based on the path specified in the submission file.
+# Files required for profiling ambient background or running dsb normalisation
 
-# If you are using a different format of file input e.g. csv matrix, 
-# make sure the two files are named using the convention:
-# {file_prefix}_filtered.csv" and {file_prefix}_raw.csv
+# The pipeline requires the raw_feature_bc_matrix folder from cellranger or equivalent,
+# specified in the submission file path with {mod}_filetype set to "cellranger," "cellranger_multi," or "10X_h5"
+# for automatic search of .h5 or matrix folder for profiling ambient background or running dsb normalization.
+
+#-------------------------------------------
+# Investigate per-channel antibody staining
+channel_col: sample_id
+save_norm_prot_mtx: False
+
+
+#----------------------
+# Protein normalization
+#----------------------
+
+normalisation_methods: clr
+
+#-----------------------------------------------
+# Centered log ratio (CLR) normalization options
+
+# margin determines whether you normalise per cell (as you would for RNA),
+# or by feature (recommended, due to the variable nature of prot assays).
+# CLR margin 0 is recommended for informative qc plots in this pipeline
+# 0 = normalise rowwise (per feature)
+# 1 = normalise colwise (per cell)
+clr_margin: 1
+
+#--------------------------------------------------------------
+# Denoised and Scaled by Background (DSB) normalization options
+quantile_clipping: True

--- a/docs/ingesting_data/pipeline.yml
+++ b/docs/ingesting_data/pipeline.yml
@@ -118,7 +118,7 @@ is_paired: True
 # use the partner_rna to specify the path to the file and provide a features_tss file with the tss coordinates
 # leave empty if multiome is used
 partner_rna:
-features_tss: #resources/features_tss_hg19.tsv
+features_tss:
 plotqc_atac_metrics: n_genes_by_counts,total_counts,pct_fragments_in_peaks,atac_peak_region_fragments,atac_mitochondrial_reads,atac_TSS_fragments
 
 # ---------------------------

--- a/docs/ingesting_mouse/pipeline.yml
+++ b/docs/ingesting_mouse/pipeline.yml
@@ -118,7 +118,7 @@ is_paired:
 # use the partner_rna to specify the path to the file and provide a features_tss file with the tss coordinates
 # leave empty if multiome is used
 partner_rna:
-features_tss: #resources/features_tss_hg19.tsv
+features_tss:
 plotqc_atac_metrics:
 
 # ---------------------------

--- a/docs/ingesting_mouse/pipeline.yml
+++ b/docs/ingesting_mouse/pipeline.yml
@@ -1,71 +1,35 @@
 # ============================================================
 # Ingest workflow Panpipes (pipeline_ingest.py)
 # ============================================================
-# written by Charlotte Rich-Griffin, Fabiola Curion
+# This file contains the parameters for the ingest workflow.
+# For full descriptions of the parameters, see the documentation at https://panpipes-pipelines.readthedocs.io/en/latest/yaml_docs/pipeline_ingestion_yml.html
 
-# This pipeline needs a sample metadata file (see resources for an example)
-# will run :
-#   summary plots of 10x metrics
-#   scrublet scores
-#   scanpy QC
-#   summary QC plots
 
-# Followed by preprocess pipeline. 
-# The ingest pipeline does not perform any filtering of cells or genes.
-# Filtering happens as the first stpe in the preprocess pipeline. See pipeline_preprocess for details
-
-# Note that if you are combining mutliple datasets from different source the final anndata object will only contain the intersect of the genes
-# from all the data sets. For example if the mitochondrial genes have been excluded from one of the inputs, they will be excluded from the final data set.
-# In this case it might be wise to run qc separately on each dataset, and them merge them together to create on h5ad file to use as input for
-# integration pipeline.
-# ------------------------
-# compute resource options
-# ------------------------
+#--------------------------
+# Compute resources options
+#--------------------------
 resources:
-  # Number of threads used for parallel jobs
-  # this must be enough memory to create to load all you input files and once and create the mudatafile
   threads_high: 1
-  # this must be enough memory to load your mudata and do computationally light tasks
   threads_medium: 1
-  # this must be enough memory to load text files and do plotting, requires much less memory than the other two
   threads_low: 1
-# path to conda env, leave blank if running native or your cluster automatically inherits the login node environment
+
 condaenv:
 
-# ------------------------------------------------------------------------------------------------
-# Loading and concatenating data options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
+# --------------------------------
+# Loading and merging data options
+# --------------------------------
+
+# ----------------------------
 # Project name and data format
-# ------------------------
 project: tutorial
 sample_prefix: mouse_lymph_node
-# if you have an existing h5mu object that you want to run through the pipeline then
-# store it in the folder where you intend to run the folder, and call it
-# ${sample_prefix}_unfilt.h5mu where ${sample_prefix} = sample_prefix argument above
 use_existing_h5mu: False
-
-# submission_file format:
-# For ingest the required columns are
-# sample_id  rna_path  rna_filetype  (prot_path  prot_filetype tcr_path  tcr_filetype etc.)
-# Example at resources/sample_file_mm.txt
 submission_file: sample_submission_file.txt
-
-# which metadata cols from the submission file do you want to include in the anndata object
-# as a comma-separated string e.g. batch,disease,sex
-metadatacols: 
-
-# which concat join do you want to perform on your mudata objects, recommended inner
-# see https://anndata.readthedocs.io/en/latest/concatenation.html#inner-and-outer-joins for details
+metadatacols:
 concat_join_type: inner
 
-
-#---------------------------------------
+#--------------------------
 # Modalities in the project
-#---------------------------------------
-# the qc scripts are independent and modalities are processed following this order. Set to True to abilitate modality(ies). 
-# Leave empty (None) or False to signal this modality is not in the experiment.
-
 modalities:
   rna: True
   prot: False
@@ -73,324 +37,142 @@ modalities:
   tcr: False
   atac: False
 
-#---------------------------------------
-# Integrating barcode level data e.g. 
-# demultiplexing with hashtags, chemical tags or lipid tagging
-#---------------------------------------
-# if you have cell level metadata such as results from a demultiplexing algorithm, 
-# you can incorporate it into the mudata object, 
-# this should be stored in one csv containing 2 columns, barcode_id, and sample_id,
-# which should match the sample_id column in the submission file.
+#--------------------------------
+# Integrating barcode level data
+# e.g. demultiplexing with hashtags, chemical tags or lipid tagging
 barcode_mtd:
   include:
   path:
   metadatacols:  
 
-#---------------------------------------
-# Loading prot data - additional options
-#---------------------------------------
-# As default the ingest will choose the first column of the cellranger features.tsv.gz
-# To merge extra information about the antibodies e.g. whether they are hashing antibodies or isotypes,
-# Create a table with the first column equivalent to the first column of cellrangers features.tsv.gz
-# and specify it below (save as txt file)
-protein_metadata_table: 
-# Make sure there are unique entries in this column for each prot.
-# include a column called isotype (containing True or False) if you want to qc isotypes
-# include a column called hashing_ab (containing True or False) if your dataset contains hashing antibodies which you wish to split into a separate modality
-
-# If you want to update the mudata index with a column from protein_metadata_table, specify here
-# If there are overlaps with the rna gene symbols, then you might have trouble down the line
-# It is recommended to add something to make the labels unique e.g. "prot_CD4"
-index_col_choice: 
-
-# If providing separate prot and rna 10X outputs, then the pipeline will load the filtered rna 10X outputs and the raw prot 10X counts
-# we assume in most cases that we want to treat filtered rna barcodes as the "real" cells
-# and we want out prot assays barcodes to match rna. In which case set subset_prot_barcodes_to_rna: True (which is also the default setting)
-# if explicitly set to False, the full prot matrix will be loaded into the mudata obect
+#------------------------------------------
+# Loading Protein data - additional options
+protein_metadata_table:
+index_col_choice:
 load_prot_from_raw: False
 subset_prot_barcodes_to_rna: False
 
 
-# ------------------------------------------------------------------------------------------------
-# QC options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
-# 10X cellranger files processing
-# ------------------------
-# if starting from cellranger outputs, you can parse multiple metrics_summary.csv files and plot them together
-# the workflow looks for the metrics_summary file in the "outs" folder and will stop if it doesn't find it.
-plot_10X_metrics: False #Set to False if not using cellranger folders as input
+# -----------------------------
+# Quality Control (QC) options
+# -----------------------------
 
-# ------------
-# Doublets on RNA - Scrublet
-# ------------
+# -----------------------------------
+# Processing of 10X cellranger metrics files
+plot_10X_metrics: False
+
+# ----------------------------------
+# Doublet detection on RNA modality
 scr:
   run: False
-  # The values here are the default values, if you were to leave a paramter pblank, it would default to these value,
   expected_doublet_rate: 0.06
-  #the expected fraction of transcriptomes that are doublets, typically 0.05-0.1.
-  # Results are not particularly sensitive to this parameter")
   sim_doublet_ratio: 2
-  # the number of doublets to simulate, relative to the number of observed transcriptomes.
-  # Setting too high is computationally expensive. Min tested 0.5
   n_neighbours: 20
-  # Number of neighbors used to construct the KNN classifier of observed transcriptomes
-  # and simulated doublets.
-  # The default value of round(0.5*sqrt(n_cells)) generally works well.
   min_counts: 2
-  # Used for gene filtering prior to PCA. Genes expressed at fewer than `min_counts` in fewer than `min_cells` (see below) are excluded"
   min_cells: 3
-  # Used for gene filtering prior to PCA.
-  # Genes expressed at fewer than `min_counts` (see above) in fewer than `min_cells` are excluded.")
   min_gene_variability_pctl: 85
-  # Used for gene filtering prior to PCA. Keep the most highly variable genes
-    # (in the top min_gene_variability_pctl percentile),
-    #as measured by the v-statistic [Klein et al., Cell 2015]")
   n_prin_comps: 30
-  # Number of principal components used to embed the transcriptomes
-  # prior to k-nearest-neighbor graph construction
   use_thr: True
-  # use a user defined thr to define min doublet score to split true from false doublets?
-  # if false just use what the software produces
-  # this threshold applies to plots, a=no actual fitlering takes place.
   call_doublets_thr: 0.25
-  #if use_thr is True, this thr will be used to define doublets
 
-# ------------
-# RNA QC
-# ------------
-# this part of the pipeline allows to generate the QC parameters that will be used to 
-# evaluate inclusion/ exclusion criteria. Filtering of cells/genes happens in the next workflow (preprocess)
-# leave options blank to avoid running, "default" (to use the data stored within the package) 
+# ----------------------------
+# RNA modality Quality Control
 
-# It's often practical to rely on known gene lists, for a series of tasks, like evaluating % of mitochondrial genes or
-# ribosomal genes, or excluding IGG genes from HVG selection. For the ingest workflow, 
-# We collect the cellcycle genes used in scanpy.score_genes_cell_cycle [Satija et al. (2015), Nature Biotechnology.] 
-# in in a file, panpipes/resources/cell_cicle_genes.tsv
-# and an example gene list in panpipes/resources/qc_genelist_1.0.csv 
+# Providing a gene list
+# see documentation at https://panpipes-pipelines.readthedocs.io/en/latest/usage/gene_list_format.html
+custom_genes_file: data/qc_gene_list_mouse_mt.csv
 
-# | mod | feature| group  |
-# |-----| -------|--------|
-# | RNA | gene_1 | mt     |
-# | RNA | gene_2 | rp     |
-# | RNA | gene_1 | exclude|
-# | RNA | gene_1 | markerX|  
-
-
-# We define "actions" on them as follows:
-
-# specify the "group" name of the genes you want to use to apply the action i.e. calc_proportion: mt will calculate
-# proportion of reads mapping to the genes whose group is "mt"
+# Defining actions on the genes
 
 # (for pipeline_ingest.py)
-# calc_proportions: calculate proportion of reads mapping to X genes over total number of reads, per cell
-# score_genes: using scanpy.score_genes function, 
-
-# (for pipeline_preprocess.py)
-# exclude: exclude these genes from the HVG selection, if they are deemed HV.
-
-#-------------------------
-# cell cycle action
-#-------------------------
-# ccgenes will plot the proportions of cell cycle genes (recommended to leave as default)
-ccgenes: 
-# Setting the `ccgenes` to `default` will calculate the phase of the cell cycle in which the cell is by using 
-# `scanpy.tl.score_genes_cell_cycle` using the file provided in panpipes/resources/cell_cicle_genes.tsv
-# Users can create their own list and specify the path in the `ccgenes` param to score the cells with a custom list.
-# If left blank, the cellcycle score will not be calculated.
-
-#-------------------------
-# custom genes actions
-#-------------------------
-custom_genes_file: data/qc_gene_list_mouse_mt.csv
 calc_proportions: hb,mt,rp,CD8cytotoxic
 score_genes: hb,mt,rp,CD8cytotoxic
 
-#------------------------
-# Plot QC 
-#------------------------
-# all metrics should be inputted as a comma separated string e.g. a,b,c
+# cell cycle action
+ccgenes:
 
-# base of the plots, it is a column in the obs, can be a comma separated string of multiple categorical 
-# plotqc_grouping_var: sample_id,rna:channel,prot:sample
-# normally is the channel also referred to "sample_id"
-# if left blank, the base of the plot will be the `sample_id` of your submission file
+# ------------------------
+# Plotting RNA QC metrics
+# all metrics should be provided as a comma separated string e.g. a,b,c
 plotqc_grouping_var: sample_id
-
-
-# ------------
-# Plot RNA QC metrics
-# ------------
-# other cell covariates in rna .obs
 plotqc_rna_metrics: pct_counts_mt,pct_counts_rp,pct_counts_hb,pct_counts_CD8cytotoxic,total_counts,n_genes_by_counts
 
+# ----------------------------
+# Plotting Protein QC metrics
 
-# ------------
-# Plot PROT QC metrics 
-# ------------
 # requires prot_path to be included in the submission file
-# all metrics should be inputted as a comma separated string e.g. a,b,c
-
-# as standard the following metrics are calculated for prot data
-# per cell metrics:
-# total_counts,log1p_total_counts,n_prot_by_counts,log1p_n_prot_by_counts
-# if isotypes can be detected then the following are calculated also:
-# total_counts_isotype,pct_counts_isotype
-# choose which ones you want to plot here
-plotqc_prot_metrics: 
-# Since the protein antibody panels usually count fewer features than the RNA, it may be interesting to
-# visualize breakdowns of single proteins plots describing their count distribution and other qc options.
-# choose which ones you want to plot here, for example
-# n_cells_by_counts,mean_counts,log1p_mean_counts,pct_dropout_by_counts,total_counts,log1p_total_counts
+# all metrics should be provided as a comma separated string e.g. a,b,c
+plotqc_prot_metrics:
 plot_metrics_per_prot: 
 
-# isotype outliers: one way to determine which cells are very sticky is to work out which cells have the most isotype UMIs
-# associated to them, to label a cell as an isotype outlier, it must meet or exceed the following crietria:
-# be in the above x% quantile by UMI counts, for at least n isotypes 
-# (e.g. above 90% quantile UMIs in at least 2 isotypes)
 identify_isotype_outliers: 
 isotype_upper_quantile: 
 isotype_n_pass: 
 
-  
-# ------------
-# Profiling Protein Ambient background
-# ------------
-# It is useful to characterise the background of your gene expression assay and antibody binding assay.
-# Inspect the plots and decide if to apply corrections, for example see Cellbender or SoupX. (currently not included in panpipes)
+# ---------------------
+# Plot ATAC QC metrics
 
-# PLEASE NOTE that this analysis can ONLY BE RUN IF YOU ARE PROVIDING RAW input starting from cellranger outputs
-# (so the "empty" droplets can be used to  estimate the BG )
-# setting asses_background to True when you don't have RAW inputs will stop the pipeline with an error.
-
-# Setting `assess_background` to True will:
-# 1. create h5mu from raw data inputs (expected as cellranger h5 or mtx folder, if you do not have this then set to False)
-# 2. Plot comparitive QC plots to compare distribution of UMI and feature counts in background and foreground
-# 3. Create heatmaps of the top features in the background, 
-# so you can compare the background contamination per channel
-assess_background:  #default False
-# typically there is a lot of cells in the full raw cellranger outputs, 
-# since we just want to get a picture of the background then we can subsample the data 
-# to a more reasonable ize. If you want to keep all the raw data then set the following to False
-downsample_background: 
-
-# -----------------------------------------------------
-# Files required for profiling ambient background or running dsb normalisation:
-# -----------------------------------------------------
-# the raw_feature_bc_matrix folder from cellranger or equivalent.
-# The pipeline will automatically look for this as a .h5 or matrix folder 
-# if the {mod}_filetype is set to "cellranger" or "cellranger_multi" or 10X_h5 
-# based on the path specified in the submission file.
-
-# If you are using a different format of file input e.g. csv matrix, 
-# make sure the two files are named using the convention:
-# {file_prefix}_filtered.csv" and {file_prefix}_raw.csv
-
-
-#----------------
-# Investigate per channel antibody staining:
-#----------------
-# This can help determine any inconsistencies in staining per channel and other QC concerns.
-# If you want to run clr normalisation on a per channel basis, then you need to 
-# specify which column in your submission file corresponds to the channel
-# at the QC stage it can be useful to look at the normalised data on a per sample or channel basis 
-# i.e. the 10X channel. 
-# this is usually the sample_id column (otherwise leave the next parameter blank)
-channel_col: 
-# It is important to note that in ingest the per channel normalised prot scores are not saved in the mudata object
-#  this is because if you perform feature normalisation (clr normalisation margin 0 or dsb normalisation), 
-#  on subsets of cells then the normalised values cannot be simply concatenated. 
-# The PROT normalisation is rerun pn the complete object in the preprocess pipeline 
-# (or you can run this pipeline with channel_col set as None)
-# it is important to note, if you choose to run the clr on a per channel basis, then it is not stored in the h5mu file.
-# if you want to save the per channel normalised values set the following to True:
-save_norm_prot_mtx: 
-
-#-------------------
-# PROT normalization
-#-------------------
-
-# comma separated string of normalisation options
-# options: dsb,clr 
-# Setting normalization method to dsb without providing raw files will stop the pipeline with an error.
-# more details in this vignette https://muon.readthedocs.io/en/latest/omics/citeseq.html
-# dsb https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.dsb.html
-# clr https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.clr.html
-normalisation_methods:  #default clr
-
-
-# CLR parameters:
-# margin determines whether you normalise per cell (as you would RNA norm), 
-# or by feature (recommended, due to the variable nature of prot assays). 
-# CLR margin 0 is recommended for informative qc plots in this pipeline
-# 0 = normalise rowwise (per feature)
-# 1 = normalise colwise (per cell)
-clr_margin: 
-
-
-# DSB parameters:
-# quantile clipping, even with normalisation, 
-# some cells get extreme outliers which can be clipped as discussed https://github.com/niaid/dsb
-# maximum value will be set at the value of the 99.5% quantile, applied per feature
-# note that this feature is in the default muon mu.pp.dsb code, but manually implemented in this code.
-quantile_clipping: 
-# in order to run DSB you must have access to the complete raw counts, including the empty droplets 
-# from both rna and protein assays, 
-# see details for how to make sure your files are compatible in the assess background section below
-
-# ------------
-# Plot ATAC QC metrics 
-# ------------
-
-# we require initializing one csv file per aggregated ATAC/multiome experiment.
-# if you need to analyse multiple samples in the same project, aggregate them with the cellranger arc pipeline
-# for multiome samples we recommend, specifying the 10X h5 input "10x_h5"
-# per_barcode_metric is only avail on cellranger arc (multiome)
-
-#is this an ATAC alone or a multiome sample?
-is_paired: 
-#this is NOT a multiome exp, but you have an RNA anndata that you would like to use for TSS enrichment, 
-#leave empty if no rna provided
-partner_rna: 
-#if this is a standalone atac (is_paired: False), please provide a feature file to run TSS enrichment.
-#supported annotations for protein coding genes provided
+# set is_paired to True if a multiome is ingested
+is_paired:
+# If this is NOT a multiome experiment, but you have an RNA anndata that you would like to use for TSS enrichment
+# use the partner_rna to specify the path to the file and provide a features_tss file with the tss coordinates
+# leave empty if multiome is used
+partner_rna:
 features_tss: #resources/features_tss_hg19.tsv
-#these will be used to plot and saved in the metadata
-# all metrics should be inputted as a comma separated string e.g. a,b,c
 plotqc_atac_metrics:
-# ------------
-# Plot Repertoire QC metrics
-# ------------
-# Repertoire data will be stored in one modality called "rep", if you provide both TCR and BCR data then this will be merged, 
-# but various functions will be fun on TCR and BCR separately
-# Review scirpy documentation for specifics of data storage https://scverse.org/scirpy/latest/index.html
 
-# compute sequence distance metric (required for clonotype definition)
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.pp.ir_dist.html#scirpy.pp.ir_dist
-# leave blank for defaults
+# ---------------------------
+# Plot Repertoire QC metrics
 ir_dist:
   metric:
   sequence:
 
-# clonotype definition 
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.tl.define_clonotypes.html#scirpy.tl.define_clonotypes
-# leave blank for defaults
 clonotype_definition:
   receptor_arms:
   dual_ir:
   within_group:
 
-# available metrics
-# rep:clone_id_size
-# rep:clonal_expansion
-# rep:receptor_type
-# rep:receptor_subtype
-# rep:chain_pairing
-# rep:multi_chain
-# rep:high_confidence
-# rep:is_cell
-# rep:extra_chains
 plotqc_rep_metrics:
+
+
+# -------------------------------------
+# Profiling Protein Ambient background
+# -------------------------------------
+# PLEASE NOTE that this analysis can only be run if your inputs are from cellranger raw outputs
+
+assess_background:
+downsample_background: 
+
+# -----------------------------------------------------
+# Files required for profiling ambient background or running dsb normalisation
+
+# The pipeline requires the raw_feature_bc_matrix folder from cellranger or equivalent,
+# specified in the submission file path with {mod}_filetype set to "cellranger," "cellranger_multi," or "10X_h5"
+# for automatic search of .h5 or matrix folder for profiling ambient background or running dsb normalization.
+
+#-------------------------------------------
+# Investigate per-channel antibody staining
+channel_col:
+save_norm_prot_mtx: 
+
+
+#----------------------
+# Protein normalization
+#----------------------
+
+normalisation_methods:
+
+#-----------------------------------------------
+# Centered log ratio (CLR) normalization options
+
+# margin determines whether you normalise per cell (as you would for RNA),
+# or by feature (recommended, due to the variable nature of prot assays).
+# CLR margin 0 is recommended for informative qc plots in this pipeline
+# 0 = normalise rowwise (per feature)
+# 1 = normalise colwise (per cell)
+clr_margin: 
+
+#--------------------------------------------------------------
+# Denoised and Scaled by Background (DSB) normalization options
+quantile_clipping:
 

--- a/docs/ingesting_multimodal_data/pipeline.yml
+++ b/docs/ingesting_multimodal_data/pipeline.yml
@@ -1,71 +1,35 @@
-# ----------------------- #
-# QC pipeline DendrouLab
-# ----------------------- #
-# written by Charlotte Rich-Griffin, Fabiola Curion
+# ============================================================
+# Ingest workflow Panpipes (pipeline_ingest.py)
+# ============================================================
+# This file contains the parameters for the ingest workflow.
+# For full descriptions of the parameters, see the documentation at https://panpipes-pipelines.readthedocs.io/en/latest/yaml_docs/pipeline_ingestion_yml.html
 
-# This pipeline needs a sample metadata file (see resources for an example)
-# will run :
-#   summary plots of 10x metrics
-#   scrublet scores
-#   scanpy QC
-#   summary QC plots
 
-# Followed by preprocess pipeline. 
-# The ingest pipeline does not perform any filtering of cells or genes.
-# Filtering happens as the first stpe in the preprocess pipeline. See pipeline_preprocess for details
-
-# Note that if you are combining mutliple datasets from different source the final anndata object will only contain the intersect of the genes
-# from all the data sets. For example if the mitochondrial genes have been excluded from one of the inputs, they will be excluded from the final data set.
-# In this case it might be wise to run qc separately on each dataset, and them merge them together to create on h5ad file to use as input for
-# integration pipeline.
-# ------------------------
-# compute resource options
-# ------------------------
+#--------------------------
+# Compute resources options
+#--------------------------
 resources:
-  # Number of threads used for parallel jobs
-  # this must be enough memory to create to load all you input files and once and create the mudatafile
   threads_high: 3
-  # this must be enough memory to load your mudata and do computationally light tasks
   threads_medium: 2
-  # this must be enough memory to load text files and do plotting, requires much less memory than the other two
   threads_low: 1
-# path to conda env, leave blank if running native or your cluster automatically inherits the login node environment
+
 condaenv:
 
-# ------------------------------------------------------------------------------------------------
-# Loading and concatenating data options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
+# --------------------------------
+# Loading and merging data options
+# --------------------------------
+
+# ----------------------------
 # Project name and data format
-# ------------------------
 project: "multimodal_tutorial"
 sample_prefix: "mm"
-# if you have an existing h5mu object that you want to run through the pipeline then
-# store it in the folder where you intend to run the folder, and call it
-# ${sample_prefix}_unfilt.h5mu where ${sample_prefix} = sample_prefix argument above
 use_existing_h5mu: False
-
-# submission_file format:
-# For ingest the required columns are
-# sample_id  rna_path  rna_filetype  (prot_path  prot_filetype tcr_path  tcr_filetype etc.)
-# Example at resources/sample_file_mm.txt
 submission_file: /tutorial_datasets/panpipes/submission_file_citeseq_vdj.tsv
-
-# which metadata cols from the submission file do you want to include in the anndata object
-# as a comma-separated string e.g. batch,disease,sex
 metadatacols: sample_id,disease_state,tissue,preservation_method,celltype
-
-# which concat join to you want to perform on your mudata objects, recommended inner
-# see https://anndata.readthedocs.io/en/latest/concatenation.html#inner-and-outer-joins for details
 concat_join_type: outer
 
-
-#---------------------------------------
+#--------------------------
 # Modalities in the project
-#---------------------------------------
-# the qc scripts are independent and modalities are processed following this order. Set to True to abilitate modality(ies). 
-# Leave empty (None) or False to signal this modality is not in the experiment.
-
 modalities:
   rna: True
   prot: True
@@ -73,250 +37,103 @@ modalities:
   tcr: True
   atac: False
 
-#---------------------------------------
-# Integrating barcode level data e.g. 
-# demultiplexing with hashtags, chemical tags or lipid tagging
-#---------------------------------------
-# if you have cell level metadata such as results from a demultiplexing algorithm, 
-# you can incorporate it into the mudata object, 
-# this should be stored in one csv containing 2 columns, barcode_id, and sample_id,
-# which should match the sample_id column in the submission file.
+#--------------------------------
+# Integrating barcode level data
+# e.g. demultiplexing with hashtags, chemical tags or lipid tagging
 barcode_mtd:
   include: False
   path:
   metadatacols:  
 
-#---------------------------------------
-# Loading prot data - additional options
-#---------------------------------------
-# As default the ingest will choose the first column of the cellranger features.tsv.gz
-# To merge extra information about the antibodies e.g. whether they are hashing antibodies or isotypes,
-# Create a table with the first column equivalent to the first column of cellrangers features.tsv.gz
-# and specify it below (save as txt file)
+#------------------------------------------
+# Loading Protein data - additional options
 protein_metadata_table: /tutorial_datasets/panpipes/protein_metadata.txt
-# Make sure there are unique entries in this column for each prot.
-# include a column called isotype (containing True or False) if you want to qc isotypes
-# include a column called hashing_ab (containing True or False) if your dataset contains hashing antibodies which you wish to split into a separate modality
-
-# If you want to update the mudata index with a column from protein_metadata_table, specify here
-# If there are overlaps with the rna gene symbols, then you might have trouble down the line
-# It is recommended to add something to make the labels unique e.g. "prot_CD4"
-index_col_choice: 
-
-# If providing separate prot and rna 10X outputs, then the pipeline will load the filtered rna 10X outputs and the raw prot 10X counts
-# we assume in most cases that we want to treat filtered rna barcodes as the "real" cells
-# and we want out prot assays barcodes to match rna. In which case set subset_prot_barcodes_to_rna: True (which is also the default setting)
-# if explicitly set to False, the full prot matrix will be loaded into the mudata obect
+index_col_choice:
 load_prot_from_raw: False
 subset_prot_barcodes_to_rna: False
 
 
-# ------------------------------------------------------------------------------------------------
-# QC options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
-# 10X qc files processing
-# ------------------------
+# -----------------------------
+# Quality Control (QC) options
+# -----------------------------
+
+# -----------------------------------
+# Processing of 10X cellranger metrics files
 plot_10X_metrics: True
 
-# ------------
-## Doublets on RNA - Scrublet
-# ------------
+# ----------------------------------
+# Doublet detection on RNA modality
 scr:
   run: True
-  # The values here are the default values, if you were to leave a paramter pblank, it would default to these value,
   expected_doublet_rate: 0.06
-  #the expected fraction of transcriptomes that are doublets, typically 0.05-0.1.
-  # Results are not particularly sensitive to this parameter")
   sim_doublet_ratio: 2
-  # the number of doublets to simulate, relative to the number of observed transcriptomes.
-  # Setting too high is computationally expensive. Min tested 0.5
   n_neighbours: 20
-  # Number of neighbors used to construct the KNN classifier of observed transcriptomes
-  # and simulated doublets.
-  # The default value of round(0.5*sqrt(n_cells)) generally works well.
   min_counts: 2
-  # Used for gene filtering prior to PCA. Genes expressed at fewer than `min_counts` in fewer than `min_cells` (see below) are excluded"
   min_cells: 3
-  # Used for gene filtering prior to PCA.
-  # Genes expressed at fewer than `min_counts` (see above) in fewer than `min_cells` are excluded.")
   min_gene_variability_pctl: 85
-  # Used for gene filtering prior to PCA. Keep the most highly variable genes
-    # (in the top min_gene_variability_pctl percentile),
-    #as measured by the v-statistic [Klein et al., Cell 2015]")
   n_prin_comps: 30
-  # Number of principal components used to embed the transcriptomes
-  # prior to k-nearest-neighbor graph construction
   use_thr: True
-  # use a user defined thr to define min doublet score to split true from false doublets?
-  # if false just use what the software produces
-  # this threshold applies to plots, a=no actual fitlering takes place.
   call_doublets_thr: 0.25
-  #if use_thr is True, this thr will be used to define doublets
 
-# ------------
-# RNA QC
-# ------------
-# this part of the pipeline allows to generate the QC parameters that will be used to 
-# evaluate inclusion/ exclusion criteria. Filtering of cells/genes happens in the following pipeline
-# pipeline_integration.py.
+# ----------------------------
+# RNA modality Quality Control
 
-# leave options blank to avoid running, "default" (the data stored within the package) 
-# cell cycle action
-# ccgenes will plot the proportions of cell cycle genes (recommended to leave as default)
-ccgenes: default
-# It's often practical to rely on known gene lists, for a series of tasks, like evaluating % of mitochondrial genes or
-# ribosomal genes, or excluding IGG genes from HVG selection. We collect useful gene lists in a file, resources/custom_gene_lists_v1.tsv, 
-# and define "actions" on them as follows:
-# (for pipeline_ingest.py)
-# calc_proportions: calculate proportion of reads mapping to X genes over total number of reads, per cell
-# score_genes: using scanpy.score_genes function, 
-# (for pipeline_integration.py)
-# exclude: exclude these genes from the HVG selection, if they are deemed HV.
-# plot_markers: plot these genes
-# 
-# custom genes actions
-
+# Providing a gene list
+# see documentation at https://panpipes-pipelines.readthedocs.io/en/latest/usage/gene_list_format.html
 custom_genes_file: /panpipes/panpipes/resources/qc_genelist_1.0.csv
+
+# Defining actions on the genes
+
+# (for pipeline_ingest.py)
 calc_proportions: hb,mt,rp,ig
 score_genes: MarkersNeutro
 
-# ------------
-# Plot RNA QC metrics
-# ------------
-# all metrics should be inputted as a comma separated string e.g. a,b,c
+# cell cycle action
+ccgenes: default
 
-# likely a combination of metadatacolumns and demultiplex_metadatacols
+# ------------------------
+# Plotting RNA QC metrics
+# all metrics should be provided as a comma separated string e.g. a,b,c
 plotqc_grouping_var: sample_id,disease_state
 plotqc_rna_metrics: doublet_scores,pct_counts_mt,pct_counts_rp,pct_counts_hb,pct_counts_ig
 
+# ----------------------------
+# Plotting Protein QC metrics
 
-# ------------
-# Plot PROT QC metrics 
-# ------------
 # requires prot_path to be included in the submission file
-# all metrics should be inputted as a comma separated string e.g. a,b,c
-
-# as standard the following metrics are calculated for prot data
-# per cell metrics:
-# total_counts,log1p_total_counts,n_prot_by_counts,log1p_n_prot_by_counts
-# if isotypes can be detected then the following are calculated also:
-# total_counts_isotype,pct_counts_isotype
-# choose which ones you want to plot here
+# all metrics should be provided as a comma separated string e.g. a,b,c
 plotqc_prot_metrics: total_counts,log1p_total_counts,n_prot_by_counts,pct_counts_isotype
-# Since the protein antibody panels usually count fewer features than the RNA, it may be interesting to
-# visualize breakdowns of single proteins plots describing their count distribution and other qc options.
-# choose which ones you want to plot here, for example
-# n_cells_by_counts,mean_counts,log1p_mean_counts,pct_dropout_by_counts,total_counts,log1p_total_counts
 plot_metrics_per_prot: total_counts,log1p_total_counts,n_cells_by_counts,mean_counts
 
-# isotype outliers: one way to determine which cells are very sticky is to work out which cells have the most isotype UMIs
-# associated to them, to label a cell as an isotype outlier, it must meet or exceed the following crietria:
-# be in the above x% quantile by UMI counts, for at least n isotypes 
-# (e.g. above 90% quantile UMIs in at least 2 isotypes)
 identify_isotype_outliers: True
 isotype_upper_quantile: 90
 isotype_n_pass: 2
 
-### Investigate per channel antibody staining:
-# This can help determine any inconsistencies in staining per channel and other QC concerns.
-# If you want to run clr normalsiation on a per channel basis, then you need to 
-# specify which column in your submission file corresponds to the channel
-# at the QC stage it can be useful to look at the normalised data on a per channel basis 
-# i.e. the 10X channel. 
-# this is usually the sample_id column (otherwise leave the next parameter blank)
-channel_col: sample_id
-# It is important to note that in ingest the per channel normalised prot scores are not saved in the mudata object
-#  this is because if you perform feature normalisation (clr normalisation margin 0 or dsb normalisation), 
-#  on subsets of cells then the normalised values cannot be simply concatenated. 
-# The PROT normalisation is rerun pn the complete object in the preprocess pipeline 
-# (or you can run this pipeline with channel_col set as None)
-# it is important to note, if you choose to run the clr on a per channel basis, then it is not stored in the h5mu file.
-# if you want to save the per channel normalised values set the following to True:
-save_norm_prot_mtx: False
+# ---------------------
+# Plot ATAC QC metrics
 
-# comma separated string of normalisation options
-# options: dsb,clr 
-# more details in this vignette https://muon.readthedocs.io/en/latest/omics/citeseq.html
-# dsb https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.dsb.html
-# clr https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.clr.html
-normalisation_methods: clr,dsb
-
-# CLR parameters:
-# margin determines whether you normalise per cell (as you would RNA norm), 
-# or by feature (recommended, due to the variable nature of prot assays). 
-# CLR margin 0 is recommended for informative qc plots in this pipeline
-# 0 = normalise colwise (per feature)
-# 1 = normalise rowwise (per cell)
-clr_margin: 0
-
-
-# DSB parameters:
-# quantile clipping, even with normalisation, 
-# some cells get extreme outliers which can be clipped as discussed https://github.com/niaid/dsb
-# maximum value will be set at the value of the 99.5% quantile, applied per feature
-# note that this feature is in the default muon mu.pp.dsb code, but manually implemented in this code.
-quantile_clipping: True
-# in order to run DSB you must have access to the complete raw counts, including the empty droplets 
-# from both rna and protein assays, 
-# see details for how to make sure your files are compatible in the assess background section below
-
-# ------------
-# Plot ATAC QC metrics 
-# ------------
-
-# we require initializing one csv file per aggregated ATAC/multiome experiment.
-# if you need to analyse multiple samples in the same project, aggregate them with the cellranger arc pipeline
-# for multiome samples we recommend, specifying the 10X h5 input "10x_h5"
-# per_barcode_metric is only avail on cellranger arc (multiome)
-
-#is this an ATAC alone or a multiome sample?
+# set is_paired to True if a multiome is ingested
 is_paired: True
-#this is NOT a multiome exp, but you have an RNA anndata that you would like to use for TSS enrichment, 
-#leave empty if no rna provided
-partner_rna: 
-#if this is a standalone atac (is_paired: False), please provide a feature file to run TSS enrichment.
-#supported annotations for protein coding genes provided
-features_tss: #resources/features_tss_hg19.tsv
-#these will be used to plot and saved in the metadata
-# all metrics should be inputted as a comma separated string e.g. a,b,c
+# If this is NOT a multiome experiment, but you have an RNA anndata that you would like to use for TSS enrichment
+# use the partner_rna to specify the path to the file and provide a features_tss file with the tss coordinates
+# leave empty if multiome is used
+partner_rna:
+features_tss:
 plotqc_atac_metrics: n_genes_by_counts,total_counts,pct_fragments_in_peaks,atac_peak_region_fragments,atac_mitochondrial_reads,atac_TSS_fragments
 
-# ------------
+# ---------------------------
 # Plot Repertoire QC metrics
-# ------------
-# Repertoire data will be stored in one modality called "rep", if you provide both TCR and BCR data then this will be merged, 
-# but various functions will be fun on TCR and BCR separately
-# Review scirpy documentation for specifics of data storage https://scverse.org/scirpy/latest/index.html
-
-# compute sequence distance metric (required for clonotype definition)
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.pp.ir_dist.html#scirpy.pp.ir_dist
-# leave blank for defaults
 ir_dist:
   metric:
   sequence:
 
-# clonotype definition 
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.tl.define_clonotypes.html#scirpy.tl.define_clonotypes
-# leave blank for defaults
 clonotype_definition:
   receptor_arms:
   dual_ir:
   within_group:
 
-# available metrics
-# rep:clone_id_size
-# rep:clonal_expansion
-# rep:receptor_type
-# rep:receptor_subtype
-# rep:chain_pairing
-# rep:multi_chain
-# rep:high_confidence
-# rep:is_cell
-# rep:extra_chains
 plotqc_rep_metrics:
+# provide a item list
  - is_cell
  - extra_chains
  - clonal_expansion
@@ -325,31 +142,45 @@ plotqc_rep_metrics:
  - rep:chain_pairing
  - rep:multi_chain
 
-  
-# ------------
+
+# -------------------------------------
 # Profiling Protein Ambient background
-# ------------
-# It is useful to chararcterise the background of your gene expression assay and antibody binding assay
-# Inspect the plots and decide if to apply corrections, for example see Cellbender or SoupX.
-# Please note that this analysis only makes sense if you are providing a RAW input (so the "empty" droplets can be used to
-# estimate the BG )
-# Setting `assess_background` to True will:
-# 1. create h5mu from raw data inputs (expected as cellranger h5 or mtx folder, if you do not have this then set to False)
-# 2. Plot comparitive QC plots to compare distribution of UMI and feature counts in background and foreground
-# 3. Create heatmaps of the top features in the background, so you can compare teh background contaimation per channel
+# -------------------------------------
+# PLEASE NOTE that this analysis can only be run if your inputs are from cellranger raw outputs
+
 assess_background: True
-# typically there is a lot of cells in the full raw cellranger outputs, 
-# since we just want to get a picture of the background then we can subsample the data 
-# to a more reasonable ize. If you want to keep all the raw data then set the following to False
 downsample_background: True
 
-# Files required for profiling ambient background or running dsb normalisation:
 # -----------------------------------------------------
-# the raw_feature_bc_matrix folder from cellranger or equivalent.
-# The pipeline will automatically look for this as a .h5 or matrix folder 
-# if the {mod}_filetype is set to "cellranger" or "cellranger_multi" or 10X_h5 
-# based on the path specified in the submission file.
+# Files required for profiling ambient background or running dsb normalisation
 
-# If you are using a different format of file input e.g. csv matrix, 
-# make sure the two files are named using the convention:
-# {file_prefix}_filtered.csv" and {file_prefix}_raw.csv
+# The pipeline requires the raw_feature_bc_matrix folder from cellranger or equivalent,
+# specified in the submission file path with {mod}_filetype set to "cellranger," "cellranger_multi," or "10X_h5"
+# for automatic search of .h5 or matrix folder for profiling ambient background or running dsb normalization.
+
+#-------------------------------------------
+# Investigate per-channel antibody staining
+channel_col: sample_id
+save_norm_prot_mtx: False
+
+
+#----------------------
+# Protein normalization
+#----------------------
+
+normalisation_methods: clr,dsb
+
+#-----------------------------------------------
+# Centered log ratio (CLR) normalization options
+
+# margin determines whether you normalise per cell (as you would for RNA),
+# or by feature (recommended, due to the variable nature of prot assays).
+# CLR margin 0 is recommended for informative qc plots in this pipeline
+# 0 = normalise rowwise (per feature)
+# 1 = normalise colwise (per cell)
+clr_margin: 0
+
+#--------------------------------------------------------------
+# Denoised and Scaled by Background (DSB) normalization options
+quantile_clipping: True
+

--- a/docs/ingesting_multiome/pipeline.yml
+++ b/docs/ingesting_multiome/pipeline.yml
@@ -1,71 +1,35 @@
-# ----------------------- #
-# QC pipeline DendrouLab
-# ----------------------- #
-# written by Charlotte Rich-Griffin, Fabiola Curion
+# ============================================================
+# Ingest workflow Panpipes (pipeline_ingest.py)
+# ============================================================
+# This file contains the parameters for the ingest workflow.
+# For full descriptions of the parameters, see the documentation at https://panpipes-pipelines.readthedocs.io/en/latest/yaml_docs/pipeline_ingestion_yml.html
 
-# This pipeline needs a sample metadata file (see resources for an example)
-# will run :
-#   summary plots of 10x metrics
-#   scrublet scores
-#   scanpy QC
-#   summary QC plots
 
-# Followed by preprocess pipeline. 
-# The ingest pipeline does not perform any filtering of cells or genes.
-# Filtering happens as the first step in the preprocess pipeline. See pipeline_preprocess for details
-
-# Note that if you are combining mutliple datasets from different source the final anndata object will only contain the intersect of the genes
-# from all the data sets. For example if the mitochondrial genes have been excluded from one of the inputs, they will be excluded from the final data set.
-# In this case it might be wise to run qc separately on each dataset, and them merge them together to create on h5ad file to use as input for
-# integration pipeline.
-# ------------------------
-# compute resource options
-# ------------------------
+#--------------------------
+# Compute resources options
+#--------------------------
 resources:
-  # Number of threads used for parallel jobs
-  # this must be enough memory to create to load all you input files and once and create the mudatafile
   threads_high: 8
-  # this must be enough memory to load your mudata and do computationally light tasks
   threads_medium: 4
-  # this must be enough memory to load text files and do plotting, requires much less memory than the other two
   threads_low: 2
-# path to conda env, leave blank if running native or your cluster automatically inherits the login node environment
+
 condaenv: /Users/fabiola.curion/Documents/devel/miniconda3/envs/pipeline_env
 
-# ------------------------------------------------------------------------------------------------
-# Loading and concatenating data options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
+# --------------------------------
+# Loading and merging data options
+# --------------------------------
+
+# ----------------------------
 # Project name and data format
-# ------------------------
 project: "mome"
 sample_prefix: "mome"
-# if you have an existing h5mu object that you want to run through the pipeline then
-# store it in the folder where you intend to run the folder, and call it
-# ${sample_prefix}_unfilt.h5mu where ${sample_prefix} = sample_prefix argument above
 use_existing_h5mu: False
-
-# submission_file format:
-# For ingest the required columns are
-# sample_id  rna_path  rna_filetype  (prot_path  prot_filetype tcr_path  tcr_filetype etc.)
-# Example at resources/sample_file_mm.txt
-submission_file: multiomecaf.txt 
-
-# which metadata cols from the submission file do you want to include in the anndata object
-# as a comma-separated string e.g. batch,disease,sex
-metadatacols: 
-
-# which concat join to you want to perform on your mudata objects, recommended inner
-# see https://anndata.readthedocs.io/en/latest/concatenation.html#inner-and-outer-joins for details
+submission_file: multiomecaf.txt
+metadatacols:
 concat_join_type: inner
 
-
-#---------------------------------------
+#--------------------------
 # Modalities in the project
-#---------------------------------------
-# the qc scripts are independent and modalities are processed following this order. Set to True to abilitate modality(ies). 
-# Leave empty (None) or False to signal this modality is not in the experiment.
-
 modalities:
   rna: True
   prot: False
@@ -73,283 +37,103 @@ modalities:
   tcr: False
   atac: True
 
-#---------------------------------------
-# Integrating barcode level data e.g. 
-# demultiplexing with hashtags, chemical tags or lipid tagging
-#---------------------------------------
-# if you have cell level metadata such as results from a demultiplexing algorithm, 
-# you can incorporate it into the mudata object, 
-# this should be stored in one csv containing 2 columns, barcode_id, and sample_id,
-# which should match the sample_id column in the submission file.
+#--------------------------------
+# Integrating barcode level data
+# e.g. demultiplexing with hashtags, chemical tags or lipid tagging
 barcode_mtd:
   include: False
   path:
   metadatacols:  
 
-#---------------------------------------
-# Loading prot data - additional options
-#---------------------------------------
-# As default the ingest will choose the first column of the cellranger features.tsv.gz
-# To merge extra information about the antibodies e.g. whether they are hashing antibodies or isotypes,
-# Create a table with the first column equivalent to the first column of cellrangers features.tsv.gz
-# and specify it below (save as txt file)
-protein_metadata_table: 
-# Make sure there are unique entries in this column for each prot.
-# include a column called isotype (containing True or False) if you want to qc isotypes
-# include a column called hashing_ab (containing True or False) if your dataset contains hashing antibodies which you wish to split into a separate modality
-
-# If you want to update the mudata index with a column from protein_metadata_table, specify here
-# If there are overlaps with the rna gene symbols, then you might have trouble down the line
-# It is recommended to add something to make the labels unique e.g. "prot_CD4"
-index_col_choice: 
-
-# If providing separate prot and rna 10X outputs, then the pipeline will load the filtered rna 10X outputs and the raw prot 10X counts
-# we assume in most cases that we want to treat filtered rna barcodes as the "real" cells
-# and we want out prot assays barcodes to match rna. In which case set subset_prot_barcodes_to_rna: True (which is also the default setting)
-# if explicitly set to False, the full prot matrix will be loaded into the mudata obect
+#------------------------------------------
+# Loading Protein data - additional options
+protein_metadata_table:
+index_col_choice:
 load_prot_from_raw: False
 subset_prot_barcodes_to_rna: False
 
 
-# ------------------------------------------------------------------------------------------------
-# QC options
-# ------------------------------------------------------------------------------------------------
-# ------------------------
-# 10X qc files processing
-# ------------------------
-# if starting from cellranger outputs, you can parse multiple metrics_summary.csv files and plot them together
-# the workflow looks for the metrics_summary file in the "outs" folder and will stop if it doesn't find it.
-plot_10X_metrics: True #Set to False if not using cellranger folders as input
+# -----------------------------
+# Quality Control (QC) options
+# -----------------------------
 
-# ------------
-# Doublets on RNA - Scrublet
-# ------------
+# -----------------------------------
+# Processing of 10X cellranger metrics files
+plot_10X_metrics: True
+
+# ----------------------------------
+# Doublet detection on RNA modality
 scr:
   run: True
-  # The values here are the default values, if you were to leave a paramter pblank, it would default to these value,
   expected_doublet_rate: 0.06
-  #the expected fraction of transcriptomes that are doublets, typically 0.05-0.1.
-  # Results are not particularly sensitive to this parameter")
   sim_doublet_ratio: 2
-  # the number of doublets to simulate, relative to the number of observed transcriptomes.
-  # Setting too high is computationally expensive. Min tested 0.5
   n_neighbours: 20
-  # Number of neighbors used to construct the KNN classifier of observed transcriptomes
-  # and simulated doublets.
-  # The default value of round(0.5*sqrt(n_cells)) generally works well.
   min_counts: 2
-  # Used for gene filtering prior to PCA. Genes expressed at fewer than `min_counts` in fewer than `min_cells` (see below) are excluded"
   min_cells: 3
-  # Used for gene filtering prior to PCA.
-  # Genes expressed at fewer than `min_counts` (see above) in fewer than `min_cells` are excluded.")
   min_gene_variability_pctl: 85
-  # Used for gene filtering prior to PCA. Keep the most highly variable genes
-    # (in the top min_gene_variability_pctl percentile),
-    #as measured by the v-statistic [Klein et al., Cell 2015]")
   n_prin_comps: 30
-  # Number of principal components used to embed the transcriptomes
-  # prior to k-nearest-neighbor graph construction
   use_thr: True
-  # use a user defined thr to define min doublet score to split true from false doublets?
-  # if false just use what the software produces
-  # this threshold applies to plots, a=no actual fitlering takes place.
   call_doublets_thr: 0.25
-  #if use_thr is True, this thr will be used to define doublets
 
-# this part of the pipeline allows to generate the QC parameters that will be used to 
-# evaluate inclusion/ exclusion criteria. Filtering of cells/genes happens in the next workflow (preprocess)
-# leave options blank to avoid running, "default" (to use the data stored within the package) 
+# ----------------------------
+# RNA modality Quality Control
 
-# It's often practical to rely on known gene lists, for a series of tasks, like evaluating % of mitochondrial genes or
-# ribosomal genes, or excluding IGG genes from HVG selection. For the ingest workflow, 
-# We collect the cellcycle genes used in scanpy.score_genes_cell_cycle [Satija et al. (2015), Nature Biotechnology.] 
-# in in a file, panpipes/resources/cell_cicle_genes.tsv
-# and an example gene list in panpipes/resources/qc_genelist_1.0.csv 
+# Providing a gene list
+# see documentation at https://panpipes-pipelines.readthedocs.io/en/latest/usage/gene_list_format.html
+custom_genes_file: panpipes-tutorials/tutorials/ingesting_data/qc_genelist_1.0.csv
 
-# | mod | feature| group  |
-# |-----| -------|--------|
-# | RNA | gene_1 | mt     |
-# | RNA | gene_2 | rp     |
-# | RNA | gene_1 | exclude|
-# | RNA | gene_1 | markerX|  
-
-
-# We define "actions" on them as follows:
-
-# specify the "group" name of the genes you want to use to apply the action i.e. calc_proportion: mt will calculate
-# proportion of reads mapping to the genes whose group is "mt"
+# Defining actions on the genes
 
 # (for pipeline_ingest.py)
-# calc_proportions: calculate proportion of reads mapping to X genes over total number of reads, per cell
-# score_genes: using scanpy.score_genes function, 
-
-# (for pipeline_integration.py)
-# exclude: exclude these genes from the HVG selection, if they are deemed HV.
-
-
-#-------------------------
-# cell cycle action
-#-------------------------
-# ccgenes will plot the proportions of cell cycle genes (recommended to leave as default)
-ccgenes: default
-# Setting the `ccgenes` to `default` will calculate the phase of the cell cycle in which the cell is by using 
-# `scanpy.tl.score_genes_cell_cycle` using the file provided in panpipes/resources/cell_cicle_genes.tsv
-# Users can create their own list and specify the path in the `ccgenes` param to score the cells with a custom list.
-# If left blank, the cellcycle score will not be calculated.
-
-#-------------------------
-# custom genes actions
-#-------------------------
-
-custom_genes_file: panpipes-tutorials/tutorials/ingesting_data/qc_genelist_1.0.csv
 calc_proportions: hb,mt,rp,ig
 score_genes: MarkersNeutro
 
-# -------------------
-# Plot QC
-# -------------------
-# all metrics should be inputted as a comma separated string e.g. a,b,c
+# cell cycle action
+ccgenes: default
 
-# base of the plots, it is a column in the obs, can be a comma separated string of multiple categorical 
-# plotqc_grouping_var: sample_id,rna:channel,prot:sample
-# normally is the channel also referred to "sample_id"
-# if left blank, the base of the plot will be the `sample_id` of your submission file
+# ------------------------
+# Plotting RNA QC metrics
+# all metrics should be provided as a comma separated string e.g. a,b,c
 plotqc_grouping_var: sample_id
-
-
-# ------------
-# Plot RNA QC metrics
-# ------------
-# other cell covariates in rna .obs
 plotqc_rna_metrics: doublet_scores,pct_counts_mt,pct_counts_rp,pct_counts_hb,pct_counts_ig
 
+# ----------------------------
+# Plotting Protein QC metrics
 
-# ------------
-# Plot PROT QC metrics 
-# ------------
 # requires prot_path to be included in the submission file
-# all metrics should be inputted as a comma separated string e.g. a,b,c
-
-# as standard the following metrics are calculated for prot data
-# per cell metrics:
-# total_counts,log1p_total_counts,n_prot_by_counts,log1p_n_prot_by_counts
-# if isotypes can be detected then the following are calculated also:
-# total_counts_isotype,pct_counts_isotype
-# choose which ones you want to plot here
+# all metrics should be provided as a comma separated string e.g. a,b,c
 plotqc_prot_metrics: total_counts,log1p_total_counts,n_prot_by_counts,pct_counts_isotype
-# Since the protein antibody panels usually count fewer features than the RNA, it may be interesting to
-# visualize breakdowns of single proteins plots describing their count distribution and other qc options.
-# choose which ones you want to plot here, for example
-# n_cells_by_counts,mean_counts,log1p_mean_counts,pct_dropout_by_counts,total_counts,log1p_total_counts
 plot_metrics_per_prot: total_counts,log1p_total_counts,n_cells_by_counts,mean_counts
 
-# isotype outliers: one way to determine which cells are very sticky is to work out which cells have the most isotype UMIs
-# associated to them, to label a cell as an isotype outlier, it must meet or exceed the following crietria:
-# be in the above x% quantile by UMI counts, for at least n isotypes 
-# (e.g. above 90% quantile UMIs in at least 2 isotypes)
 identify_isotype_outliers: True
 isotype_upper_quantile: 90
 isotype_n_pass: 2
 
-### Investigate per channel antibody staining:
-# This can help determine any inconsistencies in staining per channel and other QC concerns.
-# If you want to run clr normalsiation on a per channel basis, then you need to 
-# specify which column in your submission file corresponds to the channel
-# at the QC stage it can be useful to look at the normalised data on a per channel basis 
-# i.e. the 10X channel. 
-# this is usually the sample_id column (otherwise leave the next parameter blank)
-channel_col: sample_id
-# It is important to note that in ingest the per channel normalised prot scores are not saved in the mudata object
-#  this is because if you perform feature normalisation (clr normalisation margin 0 or dsb normalisation), 
-#  on subsets of cells then the normalised values cannot be simply concatenated. 
-# The PROT normalisation is rerun pn the complete object in the preprocess pipeline 
-# (or you can run this pipeline with channel_col set as None)
-# it is important to note, if you choose to run the clr on a per channel basis, then it is not stored in the h5mu file.
-# if you want to save the per channel normalised values set the following to True:
-save_norm_prot_mtx: False
+# ---------------------
+# Plot ATAC QC metrics
 
-# comma separated string of normalisation options
-# options: dsb,clr 
-# more details in this vignette https://muon.readthedocs.io/en/latest/omics/citeseq.html
-# dsb https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.dsb.html
-# clr https://muon.readthedocs.io/en/latest/api/generated/muon.prot.pp.clr.html
-normalisation_methods: clr
-
-# CLR parameters:
-# margin determines whether you normalise per cell (as you would RNA norm), 
-# or by feature (recommended, due to the variable nature of prot assays). 
-# CLR margin 0 is recommended for informative qc plots in this pipeline
-# 0 = normalise rowwise (per feature)
-# 1 = normalise colwise (per cell)
-clr_margin: 0
-
-
-# DSB parameters:
-# quantile clipping, even with normalisation, 
-# some cells get extreme outliers which can be clipped as discussed https://github.com/niaid/dsb
-# maximum value will be set at the value of the 99.5% quantile, applied per feature
-# note that this feature is in the default muon mu.pp.dsb code, but manually implemented in this code.
-quantile_clipping: True
-# in order to run DSB you must have access to the complete raw counts, including the empty droplets 
-# from both rna and protein assays, 
-# see details for how to make sure your files are compatible in the assess background section below
-
-# ------------
-# Plot ATAC QC metrics 
-# ------------
-
-# we require initializing one csv file per aggregated ATAC/multiome experiment.
-# if you need to analyse multiple samples in the same project, aggregate them with the cellranger arc pipeline
-# for multiome samples we recommend, specifying the 10X h5 input "10x_h5"
-# per_barcode_metric is only avail on cellranger arc (multiome)
-
-#is this an ATAC alone or a multiome sample?
+# set is_paired to True if a multiome is ingested
 is_paired: True
-#this is NOT a multiome exp, but you have an RNA anndata that you would like to use for TSS enrichment, 
-#leave empty if no rna provided
-partner_rna: 
-#if this is a standalone atac (is_paired: False), please provide a feature file to run TSS enrichment.
-#supported annotations for protein coding genes provided
-features_tss: #resources/features_tss_hg19.tsv
-#these will be used to plot and saved in the metadata
-# all metrics should be inputted as a comma separated string e.g. a,b,c
+# If this is NOT a multiome experiment, but you have an RNA anndata that you would like to use for TSS enrichment
+# use the partner_rna to specify the path to the file and provide a features_tss file with the tss coordinates
+# leave empty if multiome is used
+partner_rna:
+features_tss:
 plotqc_atac_metrics: n_genes_by_counts,total_counts,pct_fragments_in_peaks,atac_peak_region_fragments,atac_mitochondrial_reads,atac_TSS_fragments
 
-# ------------
+# ---------------------------
 # Plot Repertoire QC metrics
-# ------------
-# Repertoire data will be stored in one modality called "rep", if you provide both TCR and BCR data then this will be merged, 
-# but various functions will be fun on TCR and BCR separately
-# Review scirpy documentation for specifics of data storage https://scverse.org/scirpy/latest/index.html
-
-# compute sequence distance metric (required for clonotype definition)
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.pp.ir_dist.html#scirpy.pp.ir_dist
-# leave blank for defaults
 ir_dist:
   metric:
   sequence:
 
-# clonotype definition 
-# for more info on the following args go to 
-# https://scverse.org/scirpy/latest/generated/scirpy.tl.define_clonotypes.html#scirpy.tl.define_clonotypes
-# leave blank for defaults
 clonotype_definition:
   receptor_arms:
   dual_ir:
   within_group:
 
-# available metrics
-# rep:clone_id_size
-# rep:clonal_expansion
-# rep:receptor_type
-# rep:receptor_subtype
-# rep:chain_pairing
-# rep:multi_chain
-# rep:high_confidence
-# rep:is_cell
-# rep:extra_chains
 plotqc_rep_metrics:
+# provide a item list
  - is_cell
  - extra_chains
  - clonal_expansion
@@ -358,31 +142,45 @@ plotqc_rep_metrics:
  - rep:chain_pairing
  - rep:multi_chain
 
-  
-# ------------
+
+# -------------------------------------
 # Profiling Protein Ambient background
-# ------------
-# It is useful to chararcterise the background of your gene expression assay and antibody binding assay
-# Inspect the plots and decide if to apply corrections, for example see Cellbender or SoupX.
-# Please note that this analysis only makes sense if you are providing a RAW input (so the "empty" droplets can be used to
-# estimate the BG )
-# Setting `assess_background` to True will:
-# 1. create h5mu from raw data inputs (expected as cellranger h5 or mtx folder, if you do not have this then set to False)
-# 2. Plot comparitive QC plots to compare distribution of UMI and feature counts in background and foreground
-# 3. Create heatmaps of the top features in the background, so you can compare teh background contaimation per channel
+# -------------------------------------
+# PLEASE NOTE that this analysis can only be run if your inputs are from cellranger raw outputs
+
 assess_background: False
-# typically there is a lot of cells in the full raw cellranger outputs, 
-# since we just want to get a picture of the background then we can subsample the data 
-# to a more reasonable ize. If you want to keep all the raw data then set the following to False
 downsample_background: True
 
-# Files required for profiling ambient background or running dsb normalisation:
 # -----------------------------------------------------
-# the raw_feature_bc_matrix folder from cellranger or equivalent.
-# The pipeline will automatically look for this as a .h5 or matrix folder 
-# if the {mod}_filetype is set to "cellranger" or "cellranger_multi" or 10X_h5 
-# based on the path specified in the submission file.
+# Files required for profiling ambient background or running dsb normalisation
 
-# If you are using a different format of file input e.g. csv matrix, 
-# make sure the two files are named using the convention:
-# {file_prefix}_filtered.csv" and {file_prefix}_raw.csv
+# The pipeline requires the raw_feature_bc_matrix folder from cellranger or equivalent,
+# specified in the submission file path with {mod}_filetype set to "cellranger," "cellranger_multi," or "10X_h5"
+# for automatic search of .h5 or matrix folder for profiling ambient background or running dsb normalization.
+
+#-------------------------------------------
+# Investigate per-channel antibody staining
+channel_col: sample_id
+save_norm_prot_mtx: False
+
+
+#----------------------
+# Protein normalization
+#----------------------
+
+normalisation_methods: clr
+
+#-----------------------------------------------
+# Centered log ratio (CLR) normalization options
+
+# margin determines whether you normalise per cell (as you would for RNA),
+# or by feature (recommended, due to the variable nature of prot assays).
+# CLR margin 0 is recommended for informative qc plots in this pipeline
+# 0 = normalise rowwise (per feature)
+# 1 = normalise colwise (per cell)
+clr_margin: 0
+
+#--------------------------------------------------------------
+# Denoised and Scaled by Background (DSB) normalization options
+quantile_clipping: True
+


### PR DESCRIPTION
Closes #34.

This PR simplifies the `pipeline.yml` files for the four basic ingestion tutorials. Specifically, I deleted most of the comments and reordered the parameters in the file to match the structure of the main `pipeline.yml` file. Importantly, the parameter values were not changed, ensuring that the modifications do not result in altered behavior.