### PR TITLE
Change ATAC normalization to TFIDF-signac in preprocess tutorial

### DIFF
--- a/docs/filtering_data/filtering_data_with_panpipes.md
+++ b/docs/filtering_data/filtering_data_with_panpipes.md
@@ -167,9 +167,9 @@ You can choose to modify the parameters and re-run a specific task, for example 
 
 If you want to make changes to other parameters like changing normalization methods and then HVG selection and dimensionality reduction, rename the teaseq.h5mu object from the folder and re-run the workflow. (You can also remove all outputs except for the pipeline.yml)
 
-For example, we can change the normalization and dimensionality reduction of the ATAC modality into LSI, then remove the previous log file. We can simply change its name to keep the record of the previous run. (`mv logs/preprocess_atac.log logs/preprocess_atac.log`)
+For example, we can change the dimensionality reduction of the ATAC modality into LSI, then remove the previous log file. We can simply change its name to keep the record of the previous run. (`mv logs/preprocess_atac.log logs/preprocess_atac.log`)
 
-We rename the teaseq object with lognormalized counts and PCA for atac `teaseq_atac_pca.h5mu` since we will use it later.
+We rename the teaseq object with log-normalized counts and PCA for atac `teaseq_atac_pca.h5mu` since we will use it later.
 
 
 ```
@@ -180,7 +180,7 @@ dimred: LSI #PCA or LSI
 n_comps: 50 # how many components to compute
 ```
 
-We run `panpipes preprocess make full --local` again. Now we have in the mudata["atac"] slot,  a new normalization layer, a new set of HVF  and the LSI for the atac modality.
+We run `panpipes preprocess make full --local` again. Now we have in the mudata["atac"] slot, a new normalization layer, a new set of HVF and the LSI for the atac modality.
 
 ```
 import muon as mu

--- a/docs/filtering_data/pipeline.yml
+++ b/docs/filtering_data/pipeline.yml
@@ -284,8 +284,8 @@ prot:
 # --------------------------------------------------------------------------------------------------------
 atac:
   binarize: False
-  normalize: log1p
-  TFIDF_flavour: 
+  normalize: TFIDF
+  TFIDF_flavour: signac
 
   # highly variable feature selection:
   # HVF selection either with scanpy's pp.highly_variable_genes() function or a pseudo-FindTopFeatures() function of the signac package


### PR DESCRIPTION
Previously, `log1p` normalization was used for the ATAC data in the preprocess tutorial. This raises downstream errors in both the clustering and the visualization pipelines, as those expect a `signac_norm` layer, which is created when using `TFIDF` normalization with flavor `signac` for ATAC normalization.

I decided to adapt the ATAC normalization in the preprocess step instead of in both downstream pipelines, but I'd love to hear opinions on whether this is the best way to resolve this issue.

Closes #26.